### PR TITLE
Make specs run outside original dev environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "http://rubygems.org"
 
-#gem 'rspec', ">= 2"
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,34 @@
 PATH
   remote: .
+  specs:
+    os (1.0.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.2)
-    git (1.2.5)
-    jeweler (1.6.0)
-      bundler (~> 1.0.0)
-      git (>= 1.2.5)
-      rake
-    rake (0.8.7)
+    diff-lcs (1.1.3)
+    power_assert (1.0.2)
+    rake (0.9.6)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
       rspec-expectations (~> 2.5.0)
       rspec-mocks (~> 2.5.0)
-    rspec-core (2.5.1)
+    rspec-core (2.5.2)
     rspec-expectations (2.5.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.5.0)
+    test-unit (3.2.3)
+      power_assert
 
 PLATFORMS
   ruby
   x86-mingw32
 
 DEPENDENCIES
-  jeweler
-  rspec (>= 2.0)
+  os!
+  rake (~> 0.8)
+  rspec (~> 2.5.0)
+  test-unit (~> 3)
+
+BUNDLED WITH
+   1.14.5

--- a/os.gemspec
+++ b/os.gemspec
@@ -41,16 +41,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "2.5.2".freeze
   s.summary = "Simple and easy way to know if you're on windows or not (reliably), as well as how many bits the OS is, etc.".freeze
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<rspec>.freeze, [">= 2.0"])
-    else
-      s.add_dependency(%q<rspec>.freeze, [">= 2.0"])
-    end
-  else
-    s.add_dependency(%q<rspec>.freeze, [">= 2.0"])
-  end
+  s.add_development_dependency('rake', '~> 0.8')
+  s.add_development_dependency('rspec', '~> 2.5.0')
+  s.add_development_dependency('test-unit', '~> 3')
 end
-

--- a/spec/os_spec.rb
+++ b/spec/os_spec.rb
@@ -119,10 +119,9 @@ describe "OS" do
   end
 
   it "has working cpu count method" do
-    assert OS.cpu_count >= 1
-    if OS.mac?
-      assert OS.cpu_count == 2 # my own developer box :P
-    end
+    cpu_count = OS.cpu_count
+    assert cpu_count >= 1
+    assert (cpu_count & (cpu_count - 1)) == 0 # CPU count is normally a power of 2
   end
 
   it "has working cpu count method with no env. variable" do


### PR DESCRIPTION
- Cleans up dependency specs so bundler can install, and `bundle exec rake spec` runs properly.
- Replace a spec targeting the original development environment with a more general spec.