### PR TITLE
Add app_config_path for determining app config location

### DIFF
--- a/lib/os.rb
+++ b/lib/os.rb
@@ -260,6 +260,24 @@ class OS
 
   end
 
+  def self.app_config_path(name)
+    if OS.doze?
+      if ENV['LOCALAPPDATA']
+        return File.join(ENV['LOCALAPPDATA'], name)
+      end
+
+      File.join ENV['USERPROFILE'], 'Local Settings', 'Application Data', name
+    elsif OS.mac?
+      File.join ENV['HOME'], 'Library', 'Application Support', name
+    else
+      if ENV['XDG_CONFIG_HOME']
+        return File.join(ENV['XDG_CONFIG_HOME'], name)
+      end
+
+      File.join ENV['HOME'], '.config', name
+    end
+  end
+
   class << self
     alias :doze? :windows? # a joke name but I use it and like it :P
     alias :jruby? :java?

--- a/spec/os_spec.rb
+++ b/spec/os_spec.rb
@@ -142,6 +142,23 @@ describe "OS" do
     end
   end
 
+  it "should provide a path to directory for application config" do
+    ENV.stub(:[])
+
+    if OS.mac?
+      ENV.stub(:[]).with('HOME').and_return('/home/user')
+      assert OS.app_config_path('appname') == '/home/xdg/Library/Application Support/appname'
+    elsif OS.doze?
+      # TODO
+    else
+      ENV.stub(:[]).with('HOME').and_return('/home/user')
+      assert OS.app_config_path('appname') == '/home/user/.config/appname'
+
+      ENV.stub(:[]).with('XDG_CONFIG_HOME').and_return('/home/xdg/.config')
+      assert OS.app_config_path('appname') == '/home/xdg/.config/appname'
+    end
+  end
+
   it "should have a freebsd? method" do
     if OS.host_os =~ /freebsd/
       assert OS.freebsd? == true


### PR DESCRIPTION
This adds OS.app_config_path(name), which you can use to create a directory to store your app's config files in. I started by writing a gem for this, then realized it's probably better in something like this gem.

It's basically a port of the logic of application-config-path from NodeJS to ruby: https://github.com/LinusU/node-application-config-path

I think it's related to #23.

Tested on Linux, but not yet tested on OSX or Windows. There's no tests for windows yet because I'm not sure what the variables would look like. It would be lovely if someone tested it over on those platforms.