### PR TITLE
Added checks for Windows Subsystem for Linux on Windows 10

### DIFF
--- a/lib/os.rb
+++ b/lib/os.rb
@@ -176,11 +176,12 @@ class OS
     end
 
     def self.windows?
-      ENV['OS'] == 'Windows_NT'
+      # Windows 10 WSL kernel versions are custom to Microsoft
+      ENV['OS'] == 'Windows_NT' || !(`uname -r` =~ /Microsoft/).nil?
     end
 
     def self.linux?
-      OS.host_os =~ /linux/ ? true : false
+      !windows? && OS.host_os =~ /linux/ ? true : false
     end
 
   end


### PR DESCRIPTION
The new Windows Subsystem for Linux allows guest Linux OS's to seamlessly masquerade as an actual Linux host. However, these guests have the ability to run both Windows and Linux binaries - necessitating a need to determine if the underlying OS is actually Windows-based.

This code has been tested in MinGW32, CygWin, macOS, Ubuntu, Ubuntu on WSL, Kali on WSL, and Windows 10. 