### PR TITLE
Detect underlying Docker containers

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -52,6 +52,9 @@ The OS gem allows for some easy telling if you're on windows or not.
   >> OS::Underlying.bsd?
   => true # true for OS X
   
+  >> OS::Underlying.docker?
+  => false # true if running inside a Docker container
+  
 If there are any other features you'd like, let me know, I'll do what I can to add them :)
 
 http://github.com/rdp/os for feedback et al

--- a/lib/os.rb
+++ b/lib/os.rb
@@ -183,6 +183,10 @@ class OS
       OS.host_os =~ /linux/ ? true : false
     end
 
+    def self.docker?
+      system('grep -q docker /proc/self/cgroup') if OS.linux?
+    end
+
   end
 
   def self.cygwin?


### PR DESCRIPTION
This PR adds support for detection of underlying Docker containers by examining the Linux kernel control group of the Ruby process.

Usage:
```ruby
OS::Underlying.docker?
```