### PR TITLE
Add Linux-specific OS#parse_os_release method

### DIFF
--- a/lib/os.rb
+++ b/lib/os.rb
@@ -282,6 +282,20 @@ class OS
     end
   end
 
+  def self.parse_os_release
+    if OS.linux? && File.exist?('/etc/os-release')
+      output = {}
+
+      File.read('/etc/os-release').each_line do |line|
+        parsed_line = line.chomp.tr('"', '').split('=')
+        output[parsed_line[0].to_sym] = parsed_line[1]
+      end
+      output
+    else
+      raise "File /etc/os-release doesn't exists or not Linux"
+    end
+  end
+
   class << self
     alias :doze? :windows? # a joke name but I use it and like it :P
     alias :jruby? :java?


### PR DESCRIPTION
It takes the `/etc/os-release` file and parses it into a ruby hash
for easy access to things like distro name, id, id_like, version number,
codename, etc.

It doesn't change or break anything and I tested it well with many
virtual machines.

Cheers,

Jose Elera <jelera@gmail.com>