### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/os.gemspec
+++ b/os.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
     "spec/osx_spec.rb",
     "spec/spec_helper.rb"
   ]
-  s.homepage = "http://github.com/rdp/os".freeze
+  s.homepage = "https://github.com/rdp/os".freeze
   s.licenses = ["MIT".freeze]
   s.rubygems_version = "2.7.6".freeze
   s.summary = "Simple and easy way to know if you're on windows or not (reliably), as well as how many bits the OS is, etc.".freeze


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/os or some tools or APIs that use the gem's metadata.