### PR TITLE
OS.mac_version (w/ aliases: osx_version & x_version)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,14 @@ tmtags
 ## VIM
 *.swp
 
+## GLADIATOR
+.gladiator
+.gladiator-scratchpad
+
+## RVM
+.ruby-version
+.ruby-gemset
+
 ## PROJECT::GENERAL
 coverage
 rdoc

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ require 'os'
 >> OS.mac? # or OS.osx? or OS.x?
 => false
 
+>> OS.mac_version # or OS.osx_version or OS.x_version
+=> 12.5 # Monterey
+
 >> OS.dev_null
 => "NUL" # or "/dev/null" depending on which platform
 

--- a/lib/os.rb
+++ b/lib/os.rb
@@ -132,6 +132,17 @@ class OS
     mac?
   end
 
+  def self.mac_version
+    `sw_vers -productVersion`.chomp if mac?
+  end
+
+  def self.osx_version
+    mac_version
+  end
+
+  def self.x_version
+    mac_version
+  end
 
   # amount of memory the current process "is using", in RAM
   # (doesn't include any swap memory that it may be using, just that in actual RAM)


### PR DESCRIPTION
Hi,

I use the `OS` gem extensively in [Glimmer](https://github.com/AndyObtiva/glimmer) desktop development gems like [Glimmer DSL for SWT](https://github.com/AndyObtiva/glimmer-dsl-swt) (JRuby desktop development gem) and [Glimmer DSL for LibUI](https://github.com/AndyObtiva/glimmer-dsl-libui) (CRuby desktop development gem).

One thing that has come up lately that the `OS` gem does not support is being able to check the MacOS version in order to optimize the desktop GUI look and feel for it.

I added support for that in this Pull Request.

Cheers!