### PR TITLE
Remove `yaml` global require

### DIFF
--- a/lib/os.rb
+++ b/lib/os.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require 'rbconfig'
-require 'yaml'
 
 # a set of friendly files for determining your Ruby runtime
 # treats cygwin as linux
@@ -206,6 +205,7 @@ class OS
 
   # provides easy way to see the relevant config entries
   def self.report
+    require 'yaml'
     relevant_keys = [
       'arch',
       'host',


### PR DESCRIPTION
YAML is only used for the `report` method but uses quite a bit of memory. This lowers the memory usage by default.

Fixes #76