### PR TITLE
Bump rake from 10.5 to 12.3 to address CVE-2020-8130

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
       method_source (~> 1.0)
     rainbow (2.2.2)
       rake
-    rake (10.5.0)
+    rake (12.3.3)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -84,7 +84,7 @@ PLATFORMS
 DEPENDENCIES
   guard-rspec (~> 4.7)
   os!
-  rake (~> 10.5)
+  rake (~> 12.3)
   rspec (~> 3.12)
   rubocop-lts (~> 2.0)
   test-unit (~> 3.5)

--- a/os.gemspec
+++ b/os.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.summary = "Simple and easy way to know if you're on windows or not (reliably), as well as how many bits the OS is, etc.".freeze
 
   s.add_development_dependency('guard-rspec'.freeze, ['~> 4.7'])
-  s.add_development_dependency('rake'.freeze, ['~> 10.5'])
+  s.add_development_dependency('rake'.freeze, ['~> 12.3'])
   s.add_development_dependency('rspec'.freeze, ['~> 3.12'])
   s.add_development_dependency('rubocop-lts'.freeze, ['~> 2.0']) # For Ruby 1.8.7 compat
   s.add_development_dependency('test-unit'.freeze, ['~> 3.5'])


### PR DESCRIPTION
Addresses [CVE-2020-8130](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8130)

> There is an OS command injection vulnerability in Ruby Rake < 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character `\|`.