### PR TITLE
modernize Gemfile, update Rake as locked version has a vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,11 @@
 # encoding: utf-8
 source 'http://rubygems.org'
 
+gem 'guard-rspec'
+gem 'rake'
+gem 'rspec'
+gem 'rubocop-lts'
+gem 'test-unit'
+
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    os (1.1.4)
+    os (1.1.5)
 
 GEM
   remote: http://rubygems.org/
@@ -36,14 +36,14 @@ GEM
       shellany (~> 0.0)
     parser (2.4.0.2)
       ast (~> 2.3)
-    power_assert (2.0.2)
+    power_assert (2.0.3)
     powerpack (0.1.3)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     rainbow (2.2.2)
       rake
-    rake (10.5.0)
+    rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -73,21 +73,22 @@ GEM
       rubocop (= 0.41.2)
     ruby-progressbar (1.11.0)
     shellany (0.0.1)
-    test-unit (3.5.5)
+    test-unit (3.6.1)
       power_assert
     thor (1.2.1)
     unicode-display_width (1.8.0)
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
-  guard-rspec (~> 4.7)
+  guard-rspec
   os!
-  rake (~> 10.5)
-  rspec (~> 3.12)
-  rubocop-lts (~> 2.0)
-  test-unit (~> 3.5)
+  rake
+  rspec
+  rubocop-lts
+  test-unit
 
 BUNDLED WITH
    2.3.26

--- a/os.gemspec
+++ b/os.gemspec
@@ -7,7 +7,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'os'.freeze
-  s.version = '1.1.4'
+  s.version = '1.1.5'
 
   s.required_rubygems_version = Gem::Requirement.new('>= 0'.freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ['lib'.freeze]
@@ -28,10 +28,4 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT'.freeze]
   s.rubygems_version = '2.7.6'.freeze
   s.summary = "Simple and easy way to know if you're on windows or not (reliably), as well as how many bits the OS is, etc.".freeze
-
-  s.add_development_dependency('guard-rspec'.freeze, ['~> 4.7'])
-  s.add_development_dependency('rake'.freeze, ['~> 10.5'])
-  s.add_development_dependency('rspec'.freeze, ['~> 3.12'])
-  s.add_development_dependency('rubocop-lts'.freeze, ['~> 2.0']) # For Ruby 1.8.7 compat
-  s.add_development_dependency('test-unit'.freeze, ['~> 3.5'])
 end


### PR DESCRIPTION
This modernizes the gemspec/Gemfile a little, and closes a vulnerability in Rake by upgrading it to the latest version.