### PR TITLE
Properly parse Windows x64 Ruby.

### DIFF
--- a/lib/os.rb
+++ b/lib/os.rb
@@ -77,7 +77,7 @@ class OS
 
   def self.bits
     @bits ||= begin
-      if host_cpu =~ /_64$/ || RUBY_PLATFORM =~ /x86_64/
+      if host_cpu =~ /(_|x)64$/ || RUBY_PLATFORM =~ /x86_64/
         64
       elsif RUBY_PLATFORM == 'java' && ENV_JAVA['sun.arch.data.model'] # "32" or "64":http://www.ruby-forum.com/topic/202173#880613
         ENV_JAVA['sun.arch.data.model'].to_i


### PR DESCRIPTION
to support latest Windows x64 RubyInstaller

```ruby
RUBY_PLATFORM
=> "x64-mingw-ucrt"
```

fixes https://github.com/rdp/os/issues/32