### PR TITLE
Reset OS state for each spec example.

### DIFF
--- a/spec/config/rspec/rspec_core.rb
+++ b/spec/config/rspec/rspec_core.rb
@@ -15,4 +15,10 @@ RSpec.configure do |config|
   end
 
   config.expect_with :test_unit
+
+  config.before(:each) do
+    OS.instance_variables.each do |var|
+      OS.remove_instance_variable(var)
+    end
+  end
 end

--- a/spec/os_spec.rb
+++ b/spec/os_spec.rb
@@ -9,7 +9,7 @@ describe 'OS' do
       else
         assert OS.windows? == true
         assert OS.doze? == true
-        assert OS.posix? == false # can fail in error at times...I guess because some other spec has reset ENV on us...
+        assert OS.posix? == false
       end
       assert OS::Underlying.windows?
     elsif [/linux/, /darwin/].any? { |posix_pattern| (RbConfig::CONFIG['host_os'] =~ posix_pattern) || RUBY_PLATFORM =~ posix_pattern }


### PR DESCRIPTION
This way mocked state doesn't overflow to other specs.