### PR TITLE
Add GitHub Actions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Ruby CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        ruby: ['3.1', '3.2', '3.3', '3.4']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rspec
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    ast (2.4.2)
     coderay (1.1.3)
     diff-lcs (1.5.0)
     ffi (1.15.5)
@@ -34,15 +33,10 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    parser (2.4.0.2)
-      ast (~> 2.3)
     power_assert (2.0.2)
-    powerpack (0.1.3)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rainbow (2.2.2)
-      rake
     rake (10.5.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -60,33 +54,22 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (0.41.2)
-      parser (>= 2.3.1.1, < 3.0)
-      powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-lts (2.0.5)
-      rubocop-ruby1_9 (~> 1.0.5)
-    rubocop-ruby1_9 (1.0.5)
-      parser (= 2.4.0.2)
-      rubocop (= 0.41.2)
-    ruby-progressbar (1.11.0)
     shellany (0.0.1)
     test-unit (3.5.5)
       power_assert
     thor (1.2.1)
-    unicode-display_width (1.8.0)
 
 PLATFORMS
+  arm64-darwin-23
+  x64-mingw-ucrt
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   guard-rspec (~> 4.7)
   os!
   rake (~> 10.5)
   rspec (~> 3.12)
-  rubocop-lts (~> 2.0)
   test-unit (~> 3.5)
 
 BUNDLED WITH

--- a/os.gemspec
+++ b/os.gemspec
@@ -32,6 +32,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('guard-rspec'.freeze, ['~> 4.7'])
   s.add_development_dependency('rake'.freeze, ['~> 10.5'])
   s.add_development_dependency('rspec'.freeze, ['~> 3.12'])
-  s.add_development_dependency('rubocop-lts'.freeze, ['~> 2.0']) # For Ruby 1.8.7 compat
   s.add_development_dependency('test-unit'.freeze, ['~> 3.5'])
 end


### PR DESCRIPTION
Passes if other PRs (https://github.com/rdp/os/pull/82, https://github.com/rdp/os/pull/81, https://github.com/rdp/os/pull/80) are merged first. You can see it in action at https://github.com/RubyElders/os/pull/2.

I had to remove `rubocop-lts` for now. I'm happy to add rubocop back in modern way.

fixes https://github.com/rdp/os/issues/57